### PR TITLE
NIH TS Model Initial Commit Round 5 2024-08-11

### DIFF
--- a/data-processed/NIH-Flu_TS/metadata-NIH-Flu_TS.txt
+++ b/data-processed/NIH-Flu_TS/metadata-NIH-Flu_TS.txt
@@ -4,7 +4,7 @@ model_abbr: NIH-Flu_TS
 model_contributors: Amanda Perofsky (NIH) <amanda.perofsky@nih.gov>, Cécile Viboud (NIH) <viboudc@mail.nih.gov>
 website_url: not available
 model_version: "1.0"
-methods: Dynamic harmonic regression model with ARMA errors and exogenous covariates for cumulative vaccination coverage, seasonal vaccine effectiveness, weekly A/H3N2 circulation, and weekly influenza infections.
+methods: Dynamic harmonic regression model with ARMA errors and exogenous covariates for cumulative vaccination coverage, seasonal vaccine effectiveness, weekly A/H3N2 circulation, and lagged weekly estimated influenza infections.
 license: cc-by-4.0
 citation: not available
 


### PR DESCRIPTION
# **NIH TS Model Round 5**
- Locations: US + 38 states
- All ages combined.
- Submission does not include projections for incident deaths.
- 'sample' target includes 300 representative simulations per run grouping.
- 'quantile' and 'cdf' targets are estimated from 1000 simulations per run grouping.

## Targets included: 
- 'sample': weekly incident hospitalizations
- 'quantile': weekly cumulative hospitalizations, weekly incident hospitalizations, peak size hospitalizations
- 'cdf': weekly peak timing hospitalizations

## Simulated trajectories of weekly incident hospitalizations:
- Run groupings: N = 78 (39 locations x 2 IAV subtype scenarios)
- Stochastic runs: Each run grouping set has 300 stochastic simulations (N = 23400, 78 run groupings x 300 simulations/grouping).